### PR TITLE
Removed default stream names to allow incompatible drivers

### DIFF
--- a/in_stream.go
+++ b/in_stream.go
@@ -226,9 +226,7 @@ func newInStream(d *Device, config *InStreamConfig) (*InStream, error) {
 	if config.SoftwareLatency > 0.0 {
 		p.software_latency = C.double(config.SoftwareLatency)
 	}
-	if config.Name == "" {
-		p.name = C.CString("SoundIoInStream")
-	} else {
+	if config.Name != "" {
 		p.name = C.CString(config.Name)
 	}
 

--- a/out_stream.go
+++ b/out_stream.go
@@ -241,9 +241,7 @@ func newOutStream(d *Device, config *OutStreamConfig) (*OutStream, error) {
 	if config.SoftwareLatency > 0.0 {
 		p.software_latency = C.double(config.SoftwareLatency)
 	}
-	if config.Name == "" {
-		p.name = C.CString("SoundIoOutStream")
-	} else {
+	if config.Name != "" {
 		p.name = C.CString(config.Name)
 	}
 


### PR DESCRIPTION
Some drivers does not support naming streams.

To handle this case and avoid failing with a `SoundIoErrorOpeningDevice` error, `libsoundio` has a condition in place in case that the name is not provided (= `NULL`):
https://github.com/andrewrk/libsoundio/blob/49a1f78b50eb0f5a49d096786a95a93874a2592a/src/wasapi.c#L1362

However, this is not possible feasible in the Go bindings currently, because it forcefully sets a default name even if an empty string is provided.

This PR fixes this situation and lets the pointer be `NULL` if an empty name is provided on the Go side.